### PR TITLE
"&" -> "&amp;"

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Beer && Code Seattle</title>
+    <title>Beer &amp;&amp; Code Seattle</title>
 
     <!--[if lt IE 9]>
     <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>


### PR DESCRIPTION
Fixing incorrect use of bare ampersand in title tag. See http://www.w3.org/TR/xhtml1/guidelines.html#C_12
